### PR TITLE
fix(toml): downgrade Rust edition from 2024 to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tokio-centrifuge"
 description = "Unofficial Rust Client SDK for Centrifugo."
 version = "0.1.0"
 license = "MIT"
-edition = "2024"
+edition = "2021"
 rust-version = "1.85.0"
 
 [[example]]


### PR DESCRIPTION
Edition 2024 is still unstable — or maybe I’m missing something — but every time I get this message:

```
feature `edition2024` is required

The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0).
Consider trying a more recent nightly release.
See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```